### PR TITLE
Updated tab labels in calendar examples for clarity: changed "Automotive" to "Automotive Services", "Real Estate" to "Agent & Broker", and "Generic SMB" to "General Business".

### DIFF
--- a/docusaurus/docs/calendar/examples.mdx
+++ b/docusaurus/docs/calendar/examples.mdx
@@ -110,7 +110,7 @@ Days 21-28 are intentionally left open for flexibility, seasonal content, or to 
 
   </TabItem>
 
-  <TabItem value="automotive" label="Automotive">
+  <TabItem value="automotive" label="Automotive Services">
 
 **Best for:** Auto repair shops, car dealerships, tire shops, body shops, oil change services
 
@@ -137,7 +137,7 @@ Days 21-28 are intentionally left open for flexibility, seasonal content, or to 
 
   </TabItem>
 
-  <TabItem value="real-estate" label="Real Estate">
+  <TabItem value="real-estate" label="Agent & Broker">
 
 **Best for:** Real estate agents, brokers, property managers, real estate teams
 
@@ -164,7 +164,7 @@ Days 21-28 are intentionally left open for flexibility, seasonal content, or to 
 
   </TabItem>
 
-  <TabItem value="generic" label="Generic SMB">
+  <TabItem value="generic" label="General Business">
 
 **Best for:** Retail shops, restaurants, professional services, consultants, and any business not covered above
 


### PR DESCRIPTION
Aligning the tab names of the industries to what is marked in the Reccommended Packages